### PR TITLE
소켓 클라이언트  Kotlin 예제 추가 및 예제 디자인 변경 등

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/

--- a/docs/socket/examples.mdx
+++ b/docs/socket/examples.mdx
@@ -389,8 +389,9 @@ internal val dateGson = GsonBuilder().registerTypeAdapter(Date::class.java, obje
 
 ---
 
+예시 코드
 
-    ```go
+```go
 package main
 
 import (
@@ -590,6 +591,7 @@ $client->connect();
 
 ---
 
+예시 코드
 
 ```rust
 use serde_json::Value;

--- a/docs/socket/examples.mdx
+++ b/docs/socket/examples.mdx
@@ -348,6 +348,19 @@ class APISocket{
 }
 ```
 
+Snappy 압축 해제를 위한 확장 함수
+
+```kotlin
+import com.google.gson.*
+import org.xerial.snappy.Snappy
+
+fun Array<Any>.toJson():JsonElement{
+    val json = Snappy.uncompress(first() as ByteArray).toString(StandardCharsets.UTF_8)
+    return  JsonParser.parseString(json)
+}
+```
+
+
 Room 모델
 ```kotlin
 import com.google.gson.annotations.SerializedName

--- a/docs/socket/examples.mdx
+++ b/docs/socket/examples.mdx
@@ -13,6 +13,12 @@ import TabItem from "@theme/TabItem";
 
 <Tabs>
 <TabItem value="nodejs" label="Node.js">
+필요 라이브러리
+
+- Socket.IO 클라이언트: `socket.io-client@4.6.0`
+- Snappy: `snappy`
+
+---
 
 ```javascript
 const io = require("socket.io-client");
@@ -61,6 +67,13 @@ socket.on("donation", (compressedData) => {
 </TabItem>
 <TabItem value="python" label="Python">
 
+필요 라이브러리
+
+- Socket.IO 클라이언트: `python-socketio`
+- Snappy: `python-snappy`
+
+---
+
 ```python
 import socketio
 import snappy
@@ -106,6 +119,12 @@ sio.connect("https://socket.ssapi.kr", transports=["websocket"], timeout=5)
 
 </TabItem>
 <TabItem value="browser" label="Javascript (브라우저)">
+필요 라이브러리
+
+- Socket.IO 클라이언트: `socket.io-client@4.6.0`
+- Snappy 압축 해제: `snappyjs`
+
+---
 
 ```html
 <!DOCTYPE html>
@@ -169,6 +188,14 @@ sio.connect("https://socket.ssapi.kr", transports=["websocket"], timeout=5)
 
 </TabItem>
 <TabItem value="java" label="Java">
+
+필요 라이브러리
+
+- Socket.IO 클라이언트: `socket.io-client`
+- Snappy: `org.xerial.snappy`
+- JSON: `org.json`
+
+---
 
 ```java
 import io.socket.client.IO;
@@ -236,9 +263,134 @@ public class SocketExample {
 ```
 
 </TabItem>
-<TabItem value="go" label="Go">
+<TabItem value="kotlin" label="Kotlin">
+:::caution 주의사항
+이 예시는 github 오픈소스 기여를 통해 제공되었습니다.
+:::
 
-```go
+- `org.json` 대신 Google의 gson 라이브러리를 사용합니다.
+- 그 이외의 사항은 Java를 사용하는 예제와 같습니다.
+
+---
+
+소켓
+```kotlin
+import com.google.gson.Gson
+import io.socket.client.IO
+import io.socket.client.Socket
+import org.bukkit.Bukkit
+
+
+class APISocket{
+    internal lateinit var socket: Socket
+        private set
+
+    internal fun login(key:String){
+        val options = IO.Options()
+        options.run {
+            transports = arrayOf("websocket")
+            timeout = 5000
+            reconnection = true
+            reconnectionAttempts = Int.MAX_VALUE
+            reconnectionDelay = 1000
+            reconnectionDelayMax = 5000
+        }
+        socket = IO.socket("https://socket.ssapi.kr", options)
+
+        socket.on(Socket.EVENT_CONNECT) { args ->
+            println("소켓을 연결하였습니다.")
+            socket.emit("login", key)
+        }
+        socket.on(Socket.EVENT_DISCONNECT) { args ->
+            println("소켓 연결이 끊어졌습니다.")
+        }
+
+        socket.on("donation") { args ->
+
+            val json = args.toJson().asJsonObject
+            val streamerId = json["streamer_id"].asString; val platform = json["platform"].asString
+            val donorName = json["nickname"].asString
+            val count = json["cnt"].asInt; val amount = json["amount"].asInt
+            val message = json["message"].asString; val chatId = json["_id"].asString
+
+        }
+
+        socket.on("chat"){args ->
+            val json = args.toJson().asJsonObject
+            val platform = json["platform"].asString
+            val message = json["message"].asString
+            val name = json["nickname"].asString
+            val streamerId = json["streamer_id"].asString
+
+            //무언가 무언가 하기
+
+        }
+
+        socket.on("setReceiver"){args ->
+            val receiver = Gson().fromJson(args.toJson(), Array<String>::class.java)
+
+            //무언가 하기
+        }
+
+        socket.on("login"){ args ->
+            println("로그인하였습니다!")
+            val room = Gson().fromJson(args.toJson(), Room::class.java)
+        }
+        socket.connect()
+    }
+
+    internal fun receiveChatAlso() {
+        socket.emit("setReceiver", "chat,donation")
+    }
+
+    internal fun receiveDonationOnly() {
+        socket.emit("setReceiver", "donation")
+    }
+}
+```
+
+Room 모델
+```kotlin
+import com.google.gson.annotations.SerializedName
+import java.util.Date
+
+class Room(val id:String, val users:Array<User>, @SerializedName("users_limit") val usersLimit:Int, val createdAt:Date, val updatedAt:Date)
+```
+
+User 모델
+```kotlin
+import com.google.gson.annotations.SerializedName
+import java.util.Date
+
+class User(val platform:String, @SerializedName("streamer_id") val streamerId:String, val createdAt:Date, val updatedAt:Date)
+```
+
+Date 객체 직렬화 관련
+```kotlin
+import com.google.gson.*
+
+internal val dateGson = GsonBuilder().registerTypeAdapter(Date::class.java, object: JsonSerializer<Date> {
+    override fun serialize(src: Date?, p1: Type?, context: JsonSerializationContext?): JsonElement {
+        return context!!.serialize(
+            src?.let{ DateTimeFormatter.ISO_INSTANT.format(it.toInstant())}
+        )
+    }
+}).create()
+```
+
+</TabItem>
+<TabItem value="go" label="Go">
+필요 라이브러리
+
+- Socket.IO 클라이언트: `github.com/googollee/go-socket.io-client`
+- Snappy: `github.com/golang/snappy`
+
+---
+    :::caution 주의사항
+    이 ---는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
+    :::
+
+    ```go
 package main
 
 import (
@@ -333,6 +485,10 @@ func main() {
 
 </TabItem>
 <TabItem value="php" label="PHP">
+필요 라이브러리
+
+- Socket.IO 클라이언트: `elephantio/elephant.io`
+- Snappy: `ext-snappy`
 
 ```php
 <?php
@@ -412,6 +568,18 @@ $client->connect();
 
 </TabItem>
 <TabItem value="rust" label="Rust">
+필요 라이브러리
+
+- Socket.IO 클라이언트: `socket-io-client`
+- Snappy: `snap`
+- JSON 처리: `serde_json`
+- 비동기 런타임: `tokio`
+
+---
+
+:::caution 주의사항
+이 ---는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
+:::
 
 ```rust
 use serde_json::Value;
@@ -471,52 +639,7 @@ fn handle_compressed_data(compressed_data: &[u8]) -> Result<Value, Box<dyn Error
 </TabItem>
 </Tabs>
 
-## 필요한 라이브러리
-
-각 언어별로 필요한 라이브러리는 다음과 같습니다:
-
-### Node.js
-
-- Socket.IO 클라이언트: `socket.io-client@4.6.0`
-- Snappy: `snappy`
-
-### Python
-
-- Socket.IO 클라이언트: `python-socketio`
-- Snappy: `python-snappy`
-
-### Javascript(브라우저)
-
-- Socket.IO 클라이언트: `socket.io-client@4.6.0`
-- Snappy 압축 해제: `snappyjs`
-
-### Java
-
-- Socket.IO 클라이언트: `socket.io-client`
-- Snappy: `org.xerial.snappy`
-- JSON: `org.json`
-
-### Go
-
-- Socket.IO 클라이언트: `github.com/googollee/go-socket.io-client`
-- Snappy: `github.com/golang/snappy`
-
-### PHP
-
-- Socket.IO 클라이언트: `elephantio/elephant.io`
-- Snappy: `ext-snappy`
-
-### Rust
-
-- Socket.IO 클라이언트: `socket-io-client`
-- Snappy: `snap`
-- JSON 처리: `serde_json`
-- 비동기 런타임: `tokio`
-
 :::tip
-각 예제는 기본적인 구현을 보여주는 것이며, 실제 프로덕션 환경에서는 에러 처리, 재연결 로직, 로깅 등을 추가하는 것을 권장합니다.
+예제는 기본적인 구현 방법을 보여줍니다. 프로덕션 환경에서는 각종 예외 상황에 대한 대응이나 로그 기록 등 필요한 기능을 구현하시기 바랍니다.
 :::
 
-:::caution 주의사항
-Node.js, Python, Javascript (브라우저), Java를 제외한 다른 언어의 예시 코드는 AI가 생성한 것으로, 실제 동작을 완전히 보장하지 않을 수 있습니다. 해당 코드들은 참고용으로만 사용하시기 바랍니다.
-:::

--- a/docs/socket/examples.mdx
+++ b/docs/socket/examples.mdx
@@ -278,7 +278,6 @@ public class SocketExample {
 import com.google.gson.Gson
 import io.socket.client.IO
 import io.socket.client.Socket
-import org.bukkit.Bukkit
 
 
 class APISocket{
@@ -380,15 +379,16 @@ internal val dateGson = GsonBuilder().registerTypeAdapter(Date::class.java, obje
 
 </TabItem>
 <TabItem value="go" label="Go">
+:::caution 주의사항
+이 예시는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
+:::
 필요 라이브러리
 
 - Socket.IO 클라이언트: `github.com/googollee/go-socket.io-client`
 - Snappy: `github.com/golang/snappy`
 
 ---
-    :::caution 주의사항
-    이 ---는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
-    :::
+
 
     ```go
 package main
@@ -485,10 +485,19 @@ func main() {
 
 </TabItem>
 <TabItem value="php" label="PHP">
+
+:::caution 주의사항
+이 예시는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
+:::
+
 필요 라이브러리
 
 - Socket.IO 클라이언트: `elephantio/elephant.io`
 - Snappy: `ext-snappy`
+
+---
+
+예시 코드
 
 ```php
 <?php
@@ -568,6 +577,10 @@ $client->connect();
 
 </TabItem>
 <TabItem value="rust" label="Rust">
+:::caution 주의사항
+이 예시는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
+:::
+
 필요 라이브러리
 
 - Socket.IO 클라이언트: `socket-io-client`
@@ -577,9 +590,6 @@ $client->connect();
 
 ---
 
-:::caution 주의사항
-이 ---는 AI가 생성한 것으로 동작을 보장하지 않으니 유의하시기 바랍니다.
-:::
 
 ```rust
 use serde_json::Value;


### PR DESCRIPTION
# 예제의 형식
언어별 `Socket.IO` 예제를 구현하는 예제를 설명하는 방법을 바꾸었습니다.
- 각 언어별 의존하는 라이브러리를 최하단에 모아둔 것을 예제코드 상단에 배치
   
   이 변경으로 인해 화면 우측의 Index를 통해 각 언어별 라이브러리로 바로 이동하지 못하게 되었습니다.
   그러나 개발자에게 있어 각 언어별 의존성을 한 군데 모아놓고 비교하기보다는, 구현방법에 따른 라이브러리를 생각하는 것이 보다 직관적일 것입니다.
   
- AI 생성 경고 관련

  Go, Rust, PHP의 예제가 AI를 통해 생성되었으며 동작하지 않을 가능성이 있다는 점이 페이지 하단에 배치되어 있었습니다.
  그러니 이러한 구조는 예제를 정독하고 나서 그 끝에 알게 되는 구조입니다.
  개발자가 이 예제에 주의를 기울이기 이전에 사전에 경고하는 편이 보다 좋다고 생각합니다.

- 팁
  
  프로덕션 환경에서는 보다 여러가지에 신경을 써야만 한다는 당부사항을 보다 강한 어조로 바꾸어, 예제를 그대로 사용해서는 안 된다는 점을 강조하였습니다.
  
# 언어 추가
Kotlin 예제를 추가하였습니다.

# 기타
약간의 불편함은 있었지만, JetBrain사의 WebStrom으로 이 프로젝트를 열 수 있었습니다. 그 과정에서 `.idea` 폴더가 생성되었으며, 이것은 원격 저장소에 추가되어서는 안 되는 폴더입니다.